### PR TITLE
Application lifecycle helpers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,3 +26,5 @@ jobs:
 
       - run: |
           ./script/ci-test
+          # verify that shutdown hook created the file
+          test -e /tmp/ut-test-file

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Currently it has:
 - `utilit-belt.conv` - type conversions (string to int, int to string, etc)
 - `utlity-belt.component` - small utils which make working with Stuart Sierra's Component a bit easier
 - `utility-belt.map-keys` - easy transformations of map keys between kebab and snake case
+- `utility-belt.lifecycle` - helpers to manage Clojure application lifecycle (registering shutdown hooks etc)
 
 ## nREPL component
 
@@ -42,6 +43,26 @@ You an pass the address to bind to if you need more control:
 ```clojure
 (def system
   {:nrepl-server (utility-belt.component.nrepl/create 23211"127.0.0.1")})
+```
+
+# Lifecycle hooks
+
+`utility-belt.lifecycle` provides a set of helpers to manage application lifecycle. Best used if you're using Component. Example:
+
+```clojure
+
+(ns app.core
+  (:require [app.system]
+            [com.stuartsierra.component :as component]
+            [utility-belt.lifecycle :as life]))
+
+(def system (atom nil))
+
+(def -main []
+  (life/register-shutdown-hook :stop-system #(component/stop @system))
+  (life/register-shutdown-hook :goodbye #(println "BYYYYEEEE 👋"))
+  (life/install-shutdown-hook!)
+  (reset! system (component/start (app.system/create))))
 ```
 
 # Authors

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You an pass the address to bind to if you need more control:
 (def -main []
   (life/register-shutdown-hook :stop-system #(component/stop @system))
   (life/register-shutdown-hook :goodbye #(println "BYYYYEEEE 👋"))
-  (life/install-shutdown-hook!)
+  (life/install-shutdown-hooks!)
   (reset! system (component/start (app.system/create))))
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -12,5 +12,5 @@
              {:dependencies [[cheshire "5.9.0"]
                              [com.stuartsierra/component "0.4.0"]
                              [org.clojure/tools.logging "0.5.0"]
-                             [org.clojure/java.jdbc "0.7.11"] ;; FIXME
+                             [org.clojure/java.jdbc "0.7.11"] ;; TODO - remove this once, nomnom. utility-belt.sql is stable
                              [clj-time "0.15.2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,16 @@
-(defproject nomnom/utility-belt "1.2.1"
+(defproject nomnom/utility-belt "1.2.2-SNAPSHOT"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :url "https://github.com/nomnom-insights/nomnom.utility-belt"
   :deploy-repositories {"clojars" {:sign-releases false
-                                   :username [:gpg :env/clojars_username]
-                                   :password [:gpg :env/clojars_password]}}
+                                   :username :env/clojars_username
+                                   :password :env/clojars_password}}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [nrepl "0.6.0"]]
 
   :plugins [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
-             {:dependencies [[cheshire "5.8.1"]
+             {:dependencies [[cheshire "5.9.0"]
                              [com.stuartsierra/component "0.4.0"]
                              [org.clojure/tools.logging "0.5.0"]
-                             [org.clojure/java.jdbc "0.7.10"]
-                             [clj-time "0.15.1"]]}})
+                             [org.clojure/java.jdbc "0.7.11"] ;; FIXME
+                             [clj-time "0.15.2"]]}})

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -1,7 +1,7 @@
 (ns utility-belt.lifecycle
   (:require [clojure.tools.logging :as log]))
 
-(def ^:private hooks (atom {}))
+(def ^:private hooks (atom {:shutdown-agents shutdown-agents}))
 
 (defn register-shutdown-hook
   "Add a function to run when the application *gracefully* shuts down.
@@ -19,6 +19,4 @@
   - call shutdown-agents"
   []
   (.addShutdownHook (Runtime/getRuntime)
-                    (Thread. ^Runnable (fn shutdown-hook-runner []
-                                         (run-registerd-hooks)
-                                         (shutdown-agents)))))
+                    (Thread. ^Runnable run-registerd-hooks)))

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -1,0 +1,24 @@
+(ns utility-belt.lifecycle
+  (:require [clojure.tools.logging :as log]))
+
+(def ^:private hooks (atom {}))
+
+(defn register-shutdown-hook
+  "Add a function to run when the application *gracefully* shuts down.
+  Useful for stopping the Component system or long running threads"
+  [name hook-fn]
+  (swap! hooks assoc name hook-fn))
+
+(defn- run-registerd-hooks []
+  (for [[name hook-fn] @hooks]
+    (log/infof "shutdown-hook=%s" name (hook-fn))))
+
+(defn init-shutdown-hooks
+  "Install the shutdown handler, which will:
+  - run any registerd shutdown hooks
+  - call shutdown-agents"
+  []
+  (.addShutdownHook (Runtime/getRuntime)
+                    (Thread. ^Runnable (fn shutdown-hook-runner []
+                                         (run-registerd-hooks)
+                                         (shutdown-agents)))))

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -13,7 +13,7 @@
   (for [[name hook-fn] @hooks]
     (log/infof "shutdown-hook=%s" name (hook-fn))))
 
-(defn install-shutdown-hook!
+(defn install-shutdown-hooks!
   "Install the shutdown handler, which will:
   - run any registerd shutdown hooks
   - call shutdown-agents"

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -1,17 +1,22 @@
 (ns utility-belt.lifecycle
   (:require [clojure.tools.logging :as log]))
 
-(def ^:private hooks (atom {:shutdown-agents shutdown-agents}))
+(def hooks (atom {:shutdown-agents shutdown-agents}))
 
 (defn register-shutdown-hook
   "Add a function to run when the application *gracefully* shuts down.
   Useful for stopping the Component system or long running threads"
   [name hook-fn]
+  (log/infof "registered hook %s" name)
   (swap! hooks assoc name hook-fn))
 
-(defn- run-registered-hooks []
-  (for [[name hook-fn] @hooks]
-    (log/infof "shutdown-hook=%s" name (hook-fn))))
+(defn run-registered-hooks []
+  (mapv (fn [[name hook-fn]]
+          (try
+            (log/infof "shutdown-hook=%s" name (hook-fn))
+            (catch Exception err
+              (log/errorf err "shutdown hook=%s failed" name))))
+        @hooks))
 
 (defn install-shutdown-hooks!
   "Install the shutdown handler, which will run any registered shutdown hooks."

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -13,7 +13,7 @@
   (for [[name hook-fn] @hooks]
     (log/infof "shutdown-hook=%s" name (hook-fn))))
 
-(defn init-shutdown-hooks
+(defn install-shutdown-hook!
   "Install the shutdown handler, which will:
   - run any registerd shutdown hooks
   - call shutdown-agents"

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -9,14 +9,12 @@
   [name hook-fn]
   (swap! hooks assoc name hook-fn))
 
-(defn- run-registerd-hooks []
+(defn- run-registered-hooks []
   (for [[name hook-fn] @hooks]
     (log/infof "shutdown-hook=%s" name (hook-fn))))
 
 (defn install-shutdown-hooks!
-  "Install the shutdown handler, which will:
-  - run any registerd shutdown hooks
-  - call shutdown-agents"
+  "Install the shutdown handler, which will run any registered shutdown hooks."
   []
   (.addShutdownHook (Runtime/getRuntime)
-                    (Thread. ^Runnable run-registerd-hooks)))
+                    (Thread. ^Runnable run-registered-hooks)))

--- a/test/utility_belt/lifecycle_test.clj
+++ b/test/utility_belt/lifecycle_test.clj
@@ -1,0 +1,12 @@
+(ns utility-belt.lifecycle-test
+  (:require [utility-belt.lifecycle :as lc]
+            [clojure.java.io :as io]
+            [clojure.test :refer :all]))
+
+(def test-file (io/file "/tmp/ut-test-file"))
+
+(deftest shutdown-outer
+  (testing "should crate a file on exit"
+    (io/delete-file test-file  :silently true)
+    (lc/register-shutdown-hook :passing-test #(spit test-file "hi"))
+    (lc/install-shutdown-hooks!)))


### PR DESCRIPTION
The new `utility-belt.lifecycle` namespace helps to reduce the boilerplate around setting up shutdown hooks for Clojure applications. At minimum, it will provide a graceful shutdown facility and stop the application component system, if an appropriate hook is installed.

Example from the readme:

```clojure

(ns app.core
  (:require [app.system]
            [com.stuartsierra.component :as component]
            [utility-belt.lifecycle :as life]))

(def system (atom nil))

(def -main []
  (life/register-shutdown-hook :stop-system #(component/stop @system))
  (life/register-shutdown-hook :goodbye #(println "BYYYYEEEE 👋"))
  (life/install-shutdown-hook!)
  (reset! system (component/start (app.system/create))))
```

We can take it further and DRY-up application start, but that's a lower value addition IMHO.