### PR TITLE
Add debugging macros + deps bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Currently it has:
 - `utlity-belt.component` - small utils which make working with Stuart Sierra's Component a bit easier
 - `utility-belt.map-keys` - easy transformations of map keys between kebab and snake case
 - `utility-belt.lifecycle` - helpers to manage Clojure application lifecycle (registering shutdown hooks etc)
+- `utility-belt.debug` - helpers for debugging code, mostly locally
+
 
 ## nREPL component
 

--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>date=%date level=%level thread=%thread ns=%logger message=%msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/utility-belt "1.2.3"
+(defproject nomnom/utility-belt "1.3.0-SNAPSHOT"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :url "https://github.com/nomnom-insights/nomnom.utility-belt"
   :deploy-repositories {"clojars" {:sign-releases false

--- a/project.clj
+++ b/project.clj
@@ -13,4 +13,5 @@
                              [com.stuartsierra/component "1.0.0"]
                              [org.clojure/tools.logging "1.1.0"]
                              [ch.qos.logback/logback-classic "1.2.3"]
+                             [org.clojure/java.jdbc "0.7.11"] ;; used for time coercions
                              [clj-time "0.15.2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -5,12 +5,12 @@
                                    :username :env/clojars_username
                                    :password :env/clojars_password}}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [nrepl "0.6.0"]]
+                 [nrepl "0.7.0"]]
 
   :plugins [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
-             {:dependencies [[cheshire "5.9.0"]
-                             [com.stuartsierra/component "0.4.0"]
-                             [org.clojure/tools.logging "0.5.0"]
-                             [org.clojure/java.jdbc "0.7.11"] ;; TODO - remove this once, nomnom. utility-belt.sql is stable
+             {:dependencies [[cheshire "5.10.0"]
+                             [com.stuartsierra/component "1.0.0"]
+                             [org.clojure/tools.logging "1.1.0"]
+                             [ch.qos.logback/logback-classic "1.2.3"]
                              [clj-time "0.15.2"]]}})

--- a/src/utility_belt/debug.clj
+++ b/src/utility_belt/debug.clj
@@ -17,11 +17,11 @@
 
 (defmacro log-time
   "Like time+ but uses underlying logger facility."
-  [tag body]
+  [level tag body]
   `(let [state# (atom nil)]
-     (log/debugf "tag=%s start"  ~tag)
+     (log/logf ~level "tag=%s start"  ~tag)
      (let [elapsed#  (with-out-str
                        (time (reset! state# (do ~body))))]
-       (log/debugf "tag=%s %s" ~tag elapsed#))
-     (log/debugf "tag=%s end"  ~tag)
+       (log/logf ~level "tag=%s %s" ~tag elapsed#))
+     (log/logf ~level "tag=%s end"  ~tag)
      (deref state#)))

--- a/src/utility_belt/debug.clj
+++ b/src/utility_belt/debug.clj
@@ -4,8 +4,9 @@
     [utility-belt.time :as time]))
 
 
-(defmacro time+ [tag body]
+(defmacro time+
   "Similar to `time` macro, but prints before/after markers and associated tag"
+  [tag body]
   `(let [state# (atom nil)]
      (printf "[%s]:start %s\n"  ~tag (time/now))
      (printf "[%s] %s" ~tag (with-out-str

--- a/src/utility_belt/debug.clj
+++ b/src/utility_belt/debug.clj
@@ -1,0 +1,26 @@
+(ns utility-belt.debug
+  (:require
+    [clojure.tools.logging :as log]
+    [utility-belt.time :as time]))
+
+
+(defmacro time+ [tag body]
+  "Similar to `time` macro, but prints before/after markers and associated tag"
+  `(let [state# (atom nil)]
+     (printf "[%s]:start %s\n"  ~tag (time/now))
+     (printf "[%s] %s" ~tag (with-out-str
+                              (time (reset! state# (do ~body)))))
+     (printf "[%s]:end %s\n"  ~tag (time/now))
+     (deref state#)))
+
+
+(defmacro log-time
+  "Like time+ but uses underlying logger facility."
+  [tag body]
+  `(let [state# (atom nil)]
+     (log/debugf "tag=%s start"  ~tag)
+     (let [elapsed#  (with-out-str
+                       (time (reset! state# (do ~body))))]
+       (log/debugf "tag=%s %s" ~tag elapsed#))
+     (log/debugf "tag=%s end"  ~tag)
+     (deref state#)))

--- a/test/utility_belt/component_test.clj
+++ b/test/utility_belt/component_test.clj
@@ -1,5 +1,5 @@
 (ns utility-belt.component-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [com.stuartsierra.component :as c]
             [utility-belt.component :as component]))
 

--- a/test/utility_belt/conv_test.clj
+++ b/test/utility_belt/conv_test.clj
@@ -1,11 +1,11 @@
 (ns utility-belt.conv-test
-  (:require [clojure.test :refer :all]
-            [utility-belt.conv :refer :all]))
+  (:require [clojure.test :refer [deftest is testing]]
+            [utility-belt.conv :as conv]))
 
 (deftest simple-conversions
   (testing "simple conversions"
     (is (= 1
-           (str->int "1")))
+           (conv/str->int "1")))
 
     (is (= [1 2 3]
-           (ensure-vector '(1 2 3))))))
+           (conv/ensure-vector '(1 2 3))))))

--- a/test/utility_belt/debug_test.clj
+++ b/test/utility_belt/debug_test.clj
@@ -1,8 +1,9 @@
 (ns utility-belt.debug-test
   (:require
-    [clojure.test :refer [deftest is testing]]
-    [utility-belt.debug :as debug]
     [clojure.string :as str]
+    [clojure.test :refer [deftest is testing]]
+    [clojure.tools.logging.test :as log.test]
+    [utility-belt.debug :as debug]
     [utility-belt.time]))
 
 
@@ -16,11 +17,18 @@
              (debug/time+ :test (slow-fun))))
 
       (let [out (str/split-lines
-                 (with-out-str
-                  (debug/time+ :test (slow-fun))))]
+                  (with-out-str
+                    (debug/time+ :test (slow-fun))))]
         (is (= "[:test]:start IT IS NOW" (first out)))
         (is (= "[:test]:end IT IS NOW" (last out)))
         (is (true?
-             (not
-              (nil?
-                (re-find #".+:test.+Elapsed time.+" (second out))))))))))
+              (not
+                (nil?
+                  (re-find #".+:test.+Elapsed time.+" (second out))))))))
+    (testing "log-time"
+      (is (= :fun-fun-fun
+             (debug/log-time :test (slow-fun))))
+      (log.test/with-log
+        (debug/log-time :test (slow-fun))
+        (log.test/logged? *ns* :debug "tag=:test start")
+        (log.test/logged? *ns* :debug "tag=:test end")))))

--- a/test/utility_belt/debug_test.clj
+++ b/test/utility_belt/debug_test.clj
@@ -27,8 +27,8 @@
                   (re-find #".+:test.+Elapsed time.+" (second out))))))))
     (testing "log-time"
       (is (= :fun-fun-fun
-             (debug/log-time :test (slow-fun))))
+             (debug/log-time :info :test (slow-fun))))
       (log.test/with-log
-        (debug/log-time :test (slow-fun))
+        (debug/log-time :debug :test (slow-fun))
         (log.test/logged? *ns* :debug "tag=:test start")
         (log.test/logged? *ns* :debug "tag=:test end")))))

--- a/test/utility_belt/debug_test.clj
+++ b/test/utility_belt/debug_test.clj
@@ -1,0 +1,26 @@
+(ns utility-belt.debug-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [utility-belt.debug :as debug]
+    [clojure.string :as str]
+    [utility-belt.time]))
+
+
+(defn slow-fun [] (Thread/sleep 140) :fun-fun-fun)
+
+
+(deftest time-debugging
+  (with-redefs [utility-belt.time/now (fn [] "IT IS NOW")]
+    (testing "time+ macro"
+      (is (= :fun-fun-fun
+             (debug/time+ :test (slow-fun))))
+
+      (let [out (str/split-lines
+                 (with-out-str
+                  (debug/time+ :test (slow-fun))))]
+        (is (= "[:test]:start IT IS NOW" (first out)))
+        (is (= "[:test]:end IT IS NOW" (last out)))
+        (is (true?
+             (not
+              (nil?
+                (re-find #".+:test.+Elapsed time.+" (second out))))))))))

--- a/test/utility_belt/json_test.clj
+++ b/test/utility_belt/json_test.clj
@@ -1,5 +1,5 @@
 (ns utility-belt.json-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [utility-belt.time :as t]
             [cheshire.core :as json]
             [utility-belt.json]))

--- a/test/utility_belt/lifecycle_test.clj
+++ b/test/utility_belt/lifecycle_test.clj
@@ -10,5 +10,7 @@
     (io/delete-file test-file  :silently true)
     (lc/register-shutdown-hook :passing-test #(spit test-file "hi"))
     (lc/install-shutdown-hooks!)
-    (is true) ;; so that linter stops complaining
-    ))
+    ;; so that linter stops complaining - actual test happens
+    ;; outside of the test run and we assert the contents of the test file
+    ;; in a 2nd step, which runs in CI
+    (is true)))

--- a/test/utility_belt/lifecycle_test.clj
+++ b/test/utility_belt/lifecycle_test.clj
@@ -9,4 +9,6 @@
   (testing "should crate a file on exit"
     (io/delete-file test-file  :silently true)
     (lc/register-shutdown-hook :passing-test #(spit test-file "hi"))
-    (lc/install-shutdown-hooks!)))
+    (lc/install-shutdown-hooks!)
+    (is true) ;; so that linter stops complaining
+    ))

--- a/test/utility_belt/lifecycle_test.clj
+++ b/test/utility_belt/lifecycle_test.clj
@@ -1,7 +1,7 @@
 (ns utility-belt.lifecycle-test
   (:require [utility-belt.lifecycle :as lc]
             [clojure.java.io :as io]
-            [clojure.test :refer :all]))
+            [clojure.test :refer [deftest is testing]]))
 
 (def test-file (io/file "/tmp/ut-test-file"))
 

--- a/test/utility_belt/map_keys_test.clj
+++ b/test/utility_belt/map_keys_test.clj
@@ -1,6 +1,6 @@
 (ns utility-belt.map-keys-test
-  (:require [clojure.test :refer :all]
-            [utility-belt.map-keys :refer :all]))
+  (:require [clojure.test :refer [deftest is testing]]
+            [utility-belt.map-keys :as map-keys]))
 
 (def snake-case-tests
   [["FOO-BAR" "FOO_BAR"]
@@ -40,14 +40,14 @@
   (testing "snake cases strings and keywords"
     (mapv
      (fn [[test-case expect]]
-       (is (= expect (to-snake-case test-case))))
+       (is (= expect (map-keys/to-snake-case test-case))))
      snake-case-tests)))
 
 (deftest kebab-case-test
   (testing "kebab cases strings and keywords"
     (mapv
      (fn [[test-case expect]]
-       (is (= expect (to-kebab-case test-case))))
+       (is (= expect (map-keys/to-kebab-case test-case))))
      kebab-case-tests)))
 
 (deftest snakeify-keys-test
@@ -59,7 +59,7 @@
             [{"working_key" 20}
              {"another_working_key" 10}]
             "values_are_safe" "je-suis-safe"}
-           (snakeify-keys snake-case-keys-tests))))
+           (map-keys/snakeify-keys snake-case-keys-tests))))
   (testing "snake cases and applies passed fn"
     (is (= {:FOO_BAR {:nested {:nested_2 "foo"}}
             :not_so_nested "wow"
@@ -68,7 +68,7 @@
             [{:working_key 20}
              {:another_working_key 10}]
             :values_are_safe "je-suis-safe"}
-           (snakeify-keys snake-case-keys-tests keyword)))))
+           (map-keys/snakeify-keys snake-case-keys-tests keyword)))))
 
 (deftest kebabify-keys-test
   (testing "kebabifies cases all keys"
@@ -79,7 +79,7 @@
             [{"working-key" 20}
              {"another-working-key" 10}]
             "values-are-safe" "je_suis_safe"}
-           (kebabify-keys kebab-case-keys-tests))))
+           (map-keys/kebabify-keys kebab-case-keys-tests))))
   (testing "kebabifies and applies passed fn"
     (is (= {:FOO-BAR {:nested {:nested-2 "foo"}}
             :not-so-nested "wow"
@@ -88,11 +88,11 @@
             [{:working-key 20}
              {:another-working-key 10}]
             :values-are-safe "je_suis_safe"}
-           (kebabify-keys kebab-case-keys-tests keyword)))))
+           (map-keys/kebabify-keys kebab-case-keys-tests keyword)))))
 
 (deftest keywordized-versions
   (testing "mmm kebab"
-    (let [kebab-keywords (kebabify-keys-kw kebab-case-keys-tests)]
+    (let [kebab-keywords (map-keys/kebabify-keys-kw kebab-case-keys-tests)]
       (is (= {:FOO-BAR {:nested {:nested-2 "foo"}}
               :not-so-nested "wow"
               :strings-work "working"
@@ -109,4 +109,4 @@
             [{:working_key 20}
              {:another_working_key 10}]
             :values_are_safe "je-suis-safe"}
-           (snakeify-keys-kw snake-case-keys-tests)))))
+           (map-keys/snakeify-keys-kw snake-case-keys-tests)))))

--- a/test/utility_belt/time_test.clj
+++ b/test/utility_belt/time_test.clj
@@ -1,25 +1,25 @@
 (ns utility-belt.time-test
   (:require
-   [utility-belt.time :refer :all]
-   [clojure.test :refer :all]
+   [utility-belt.time :as t]
+   [clojure.test :refer [deftest is testing]]
    [clj-time.core :as time])
   (:import (java.sql Timestamp)))
 
 (deftest sql-data-test
   (testing "convert to/form sql date")
-  (let [date (now)
-        sql-date (to-sql-time date)]
+  (let [date (t/now)
+        sql-date (t/to-sql-time date)]
     (is (instance? Timestamp sql-date))
-    (is (time/equal? date (from-sql-date sql-date)))))
+    (is (time/equal? date (t/from-sql-date sql-date)))))
 
 (deftest to-seconds-test
   (testing "convert datetime string to UTF seconds"
-    (is (= 3601 (to-seconds "1970-01-01 01:00:01")))))
+    (is (= 3601 (t/to-seconds "1970-01-01 01:00:01")))))
 
 (deftest end-of-day-time-test
-  (with-redefs [now (fn [] (->date-time "2016-12-31T00:01"))]
+  (with-redefs [t/now (fn [] (t/->date-time "2016-12-31T00:01"))]
     (testing "end of day in future"
-      (is (= (->date-time "2016-12-31T00:01") (end-of-day-time "2016-12-31"))))
+      (is (= (t/->date-time "2016-12-31T00:01") (t/end-of-day-time "2016-12-31"))))
     (testing "end of day in past"
-      (is (= (->date-time "2016-01-01T23:59:59.999") (end-of-day-time "2016-01-01")))
-      (is (= (->date-time "2016-01-01T23:59:59.999") (end-of-day-time "2016-01-01T00:01:01"))))))
+      (is (= (t/->date-time "2016-01-01T23:59:59.999") (t/end-of-day-time "2016-01-01")))
+      (is (= (t/->date-time "2016-01-01T23:59:59.999") (t/end-of-day-time "2016-01-01T00:01:01"))))))


### PR DESCRIPTION
Adds two macros:

- `utility-belt.debug/time+` - like `time` but can be tagged so it helps with timing multiple things at the same *time*
- `utility-belt.debug/log-time` - like the above but uses provided logger via `clojure.tools.logging`

Also, dependency bump and tiny test clean up.