### PR TITLE
Release 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ a limited set of dependencies.
 Currently it has:
 
 - `utility-belt.id` - various functions for working with UUIDs
+- `utility-belt.base64` - encoding/decoding of base64 into bytes/strings
 - `utility-belt.json` - sets up automatic conversions of Joda time objects to/from JSON, you need to pull in `clj-time` and `cheshire` if you need to use those
 - `utility-belt.time` - common functions for date and time calculations, you need to pull in `clj-time` if you need to use those
 - `utilit-belt.conv` - type conversions (string to int, int to string, etc)
@@ -22,6 +23,8 @@ Currently it has:
 - `utility-belt.map-keys` - easy transformations of map keys between kebab and snake case
 - `utility-belt.lifecycle` - helpers to manage Clojure application lifecycle (registering shutdown hooks etc)
 - `utility-belt.debug` - helpers for debugging code, mostly locally
+- `utility-belt.validation` - helpers for data validation
+- `utility-belt.sanitization` - helpers for data sanitization
 
 
 ## nREPL component

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/utility-belt "1.3.2"
+(defproject nomnom/utility-belt "1.3.3"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :url "https://github.com/nomnom-insights/nomnom.utility-belt"
   :deploy-repositories {"clojars" {:sign-releases false

--- a/src/utility_belt/base64.clj
+++ b/src/utility_belt/base64.clj
@@ -1,0 +1,53 @@
+(ns utility-belt.base64
+  "Encoding and decoding to and from base64"
+  (:import
+    [java.nio.charset Charset StandardCharsets]
+    [java.util Base64 Base64$Decoder Base64$Encoder]))
+
+(def ^Base64$Decoder decoder (Base64/getDecoder))
+(def ^Base64$Encoder encoder (Base64/getEncoder))
+
+(def default-charset (.toString StandardCharsets/UTF_8))
+
+(defn decode
+  "Decode from bytes or string to bytes"
+  ^bytes [base64]
+  {:pre [(or (bytes? base64) (string? base64))]}
+  (byte-array
+    ;; needs to cond on type to stop reflection
+    (cond
+      (bytes? base64) (.decode decoder ^bytes base64)
+      (string? base64) (.decode decoder ^String base64 ))))
+
+(defn decode->str
+  "Decode from bytes or string to string"
+  (^String [base64]
+    (decode->str base64 default-charset))
+  (^String [base64 ^String encoding]
+    {:pre [(Charset/isSupported encoding)]}
+    (String. (decode base64) encoding)))
+
+(defn- to-bytes
+  "Ensure data is bytes"
+  ^bytes [data ^String encoding]
+  {:pre [(or (bytes? data) (string? data))
+         (Charset/isSupported encoding)]}
+  (cond
+    (bytes? data) data
+    (string? data) (.getBytes ^String data encoding)))
+
+(defn encode
+  "Encode string or bytes to bytes"
+  (^bytes [data]
+   (encode data default-charset))
+  (^bytes [data ^String encoding]
+   (let [^bytes to-encode (to-bytes data encoding)]
+     (.encode encoder to-encode))))
+
+(defn encode->str
+  "Encode string or bytes to string"
+  (^String [data]
+   (encode->str data default-charset))
+  (^String [data ^String encoding]
+   (-> data (encode encoding) (String. encoding))))
+

--- a/src/utility_belt/conv.clj
+++ b/src/utility_belt/conv.clj
@@ -1,7 +1,8 @@
 (ns utility-belt.conv)
 
 
-(defn str->int
+;; Deprecated: clojure.core/parse-long
+(defn ^{:Deprecated "1.3.3"} str->int
   [s]
   (if (string? s)
     (Integer/parseInt s)

--- a/src/utility_belt/id.clj
+++ b/src/utility_belt/id.clj
@@ -1,21 +1,24 @@
 (ns utility-belt.id
-  "ID generation of any sort"
+  "ID generation of any sort
+   Deprecated: this namespace is being deprecated from v1.3.3
+
+   Replacements for the main functions are now available in clojure's core:
+   utility-belt.id/uuid => clojure.core/random-uuid
+   utility-belt.id/str->uuid => clojure.core/parse-uuid"
   (:import
-    (java.util
-      UUID)))
+    (java.util UUID)))
 
-
-(defn uuid
+(defn ^{:deprecated "1.3.3"} uuid
   []
   (UUID/randomUUID))
 
 
-(defn uuid-str
+(defn ^{:Deprecated "1.3.3"} uuid-str
   []
   (str (UUID/randomUUID)))
 
 
-(defn str->uuid
+(defn ^{:deprecated "1.3.3"} str->uuid
   "Convert string uuid to uuid."
   [uuid-str]
   (if (string? uuid-str)
@@ -23,6 +26,6 @@
     uuid-str))
 
 
-(defn uuid->str
+(defn ^{:deprecated "1.3.3"} uuid->str
   [uuid]
   (str uuid))

--- a/src/utility_belt/sanitization.clj
+++ b/src/utility_belt/sanitization.clj
@@ -1,0 +1,19 @@
+(ns utility-belt.sanitization
+  (:require
+    [clojure.string]
+    [utility-belt.validation]))
+
+(defn remove-spaces
+  "Remove all spaces from a string"
+  [st]
+  {:pre [(string? st)]}
+  (clojure.string/replace st #"\s" ""))
+
+(defn email
+  "Clean email string and return allowed email using validation/pattern"
+  [email]
+  {:pre [(string? email)]}
+  (when-let [email (-> email
+                       (clojure.string/lower-case)
+                       (remove-spaces))]
+    (re-find utility-belt.validation/email-pattern email)))

--- a/src/utility_belt/validation.clj
+++ b/src/utility_belt/validation.clj
@@ -5,5 +5,4 @@
 (def email-pattern-string
   #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
 
-
 (def email-pattern (re-pattern email-pattern-string))

--- a/test/utility_belt/base64_test.clj
+++ b/test/utility_belt/base64_test.clj
@@ -1,0 +1,37 @@
+(ns utility-belt.base64-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [utility-belt.base64 :as base64]))
+
+(def default-charset "UTF-8")
+(def ^String test-str "a test string encoded as base64")
+(def ^bytes test-str-bytes (.getBytes test-str default-charset))
+(def ^String test-str-64 "YSB0ZXN0IHN0cmluZyBlbmNvZGVkIGFzIGJhc2U2NA==")
+(def ^bytes test-str-64-bytes (.getBytes test-str-64 default-charset))
+
+(defn same-bytes?
+  "= doesn't work with bytes but (= seq seq) compares 1-1"
+  [^bytes a ^bytes b]
+  (= (seq a) (seq b)))
+
+(deftest same-bytes-test
+  (testing "not same"
+    (is (not (same-bytes? (.getBytes "a" "UTF-8") (.getBytes "b" "UTF-8")))))
+  (testing "same"
+    (is (same-bytes? (.getBytes "a" "UTF-8") (.getBytes "a" "UTF-8")))))
+
+(deftest encode-decode-test
+  (testing "decodes bytes"
+    (is (same-bytes? test-str-bytes (base64/decode test-str-64-bytes))))
+  (testing "decodes strings"
+    (is (same-bytes? test-str-bytes (base64/decode test-str-64))))
+  (testing "decodes bytes/strings to string"
+    (is (= test-str (base64/decode->str test-str-64-bytes)))
+    (is (= test-str (base64/decode->str test-str-64))))
+  (testing "encodes bytes"
+    (is (same-bytes? test-str-64-bytes (base64/encode test-str-bytes))))
+  (testing "encodes strings"
+    (is (same-bytes? test-str-64-bytes (base64/encode test-str))))
+  (testing "encodes bytes/strings to string"
+    (is (= test-str-64 (base64/encode->str test-str)))
+    (is (= test-str-64 (base64/encode->str test-str-bytes)))))

--- a/test/utility_belt/sanitization_test.clj
+++ b/test/utility_belt/sanitization_test.clj
@@ -1,0 +1,35 @@
+(ns utility-belt.sanitization-test
+  (:require
+    [clojure.test :refer [is deftest testing]]
+    [utility-belt.sanitization :as sanitization]))
+
+(deftest remove-spaces-test
+  (testing "it removes all spaces"
+    (is (= "itremovedallspaces"
+           (sanitization/remove-spaces "it removed all spaces")))
+    (is (= "itremovedallspacescool"
+           (sanitization/remove-spaces "  \n   it  \r removed a l l spaces        cool")))
+    (is (= "foo@cool.com"
+           (sanitization/remove-spaces "foo@\ncool.com"))))
+  (testing "it keeps original string if no spaces"
+    (is (= "foo@cool.com" (sanitization/remove-spaces "foo@cool.com")))))
+
+(def expected-emails
+  [["test@example.com" "test@example.com"]
+   ["    test@ e x a m p l e   . com  " "test@example.com"]
+   ["@example.com" nil]
+   ["ok@example." nil]
+   ["foo" nil]
+   ["ok.lolling@then.example.com" "ok.lolling@then.example.com"]
+   ["ok_lolling-1@then.example" "ok_lolling-1@then.example"]
+   ["ok_lolling-1+cool-label_ok@then" nil]
+   ["ok_lolling-1+cool-label_ok@then.example.com" "ok_lolling-1+cool-label_ok@then.example.com"]])
+
+(deftest email-test
+  (testing "sanitizes email"
+    (mapv
+      (fn [[to-clean res]]
+        (is
+          (= res (sanitization/email to-clean))
+          (str to-clean " clean should be " res)))
+      expected-emails)))


### PR DESCRIPTION
Deprecations + base64 + sanitization

## New

- utility-belt.base64: adds utilities to encode/decode strings/bytes to and from base64
- utility-belt.sanitization: sanitize data namespace. For this release, only email + space removal.

## Deprecation warns

- utility-belt.id: all functions in this namespace are going to be deprecated. These are now present in clojure.core (parse-uuid + random-uuid)